### PR TITLE
Cloudinary media

### DIFF
--- a/admin/server/api/cloudinary.js
+++ b/admin/server/api/cloudinary.js
@@ -33,7 +33,7 @@ module.exports = {
 	autocomplete: function (req, res) {
 		var cloudinary = require('cloudinary');
 		var type = req.params.type;
-		var max = req.query.max || 10;
+		var max = req.query.max || 100;
 		var prefix = req.query.prefix || '';
 		var next = req.query.next || null;
 
@@ -58,7 +58,7 @@ module.exports = {
 		var cloudinary = require('cloudinary');
 		var imageResult;
 
-		var max = req.query.max || 10;
+		var max = req.query.max || 100;
 		var prefix = req.query.prefix || '';
 		var next = req.query.next || null;
 

--- a/admin/server/api/cloudinary.js
+++ b/admin/server/api/cloudinary.js
@@ -35,49 +35,47 @@ module.exports = {
 		var max = req.query.max || 50;
 		var prefix = req.query.prefix || '';
 
-		var collection = []
+		var collection = [];
 		iterateCloudinary(collection, type, max, prefix, null,
-			function(error, callbackResult) {
+			function (error, callbackResult) {
 				if (error) {
-					res.json(error)
+					res.json(error);
 				} else {
 					res.json({
-						items: callbackResult.sort(sortById)
+						items: callbackResult.sort(sortById),
 					});
 				}
-		})
+			});
 	},
 	autocompletemedia: function (req, res) {
-		var cloudinary = require('cloudinary');
 		var async = require('async');
 
-		var type = req.params.type || 'image';
 		var max = req.query.max || 50;
 		var prefix = req.query.prefix || '';
-		var next = req.query.next || null;
 
-		var collection = []
+		var collection = [];
 
 		async.parallel([
-			function(callback) { iterateCloudinary(collection, 'image', max, prefix, null, callback) },
-			function(callback) { iterateCloudinary(collection, 'video', max, prefix, null, callback) }
+			function (callback) { iterateCloudinary(collection, 'image', max, prefix, null, callback); },
+			function (callback) { iterateCloudinary(collection, 'video', max, prefix, null, callback); },
 		],
-		function(error, results){
+		function (error, results) {
 			if (error) {
-				res.json(error)
+				res.json(error);
 			} else {
-				results[0].sort(sortById)
-				results[1].sort(sortById)
+				results[0].sort(sortById);
+				results[1].sort(sortById);
 
 				res.json({
-					items: results[0].concat(results[1])
+					items: results[0].concat(results[1]),
 				});
 			}
-		})
+		});
 	},
 
 	get: function (req, res) {
 		var cloudinary = require('cloudinary');
+
 		cloudinary.api.resource(req.query.id, function (result) {
 			if (result.error) {
 				res.json({ error: { message: result.error.message } });
@@ -88,21 +86,22 @@ module.exports = {
 	},
 };
 
-function iterateCloudinary(collection, type, max, prefix, next, callback) {
-	var cloudinary = require('cloudinary')
+function iterateCloudinary (collection, type, max, prefix, next, callback) {
+	var cloudinary = require('cloudinary');
+
 	cloudinary.api.resources(function (result) {
 		if (result.error) {
-			callback({ error: { message: result.error.message } }, null)
+			callback({ error: { message: result.error.message } }, null);
 		} else {
 			if (collection.length === 0) {
-				collection = result.resources
+				collection = result.resources;
 			} else {
-				collection = collection.concat(result.resources)
+				collection = collection.concat(result.resources);
 			}
 			if (result.next_cursor) {
-				iterateCloudinary(collection, type, max, prefix, result.next_cursor, callback)
+				iterateCloudinary(collection, type, max, prefix, result.next_cursor, callback);
 			} else {
-				callback(null, collection)
+				callback(null, collection);
 			}
 		};
 	}, {
@@ -114,12 +113,15 @@ function iterateCloudinary(collection, type, max, prefix, next, callback) {
 	});
 }
 
-function sortById(a,b) {
-  if (a.public_id < b.public_id)
-    return -1;
-  else if (a.public_id > b.public_id)
-    return 1;
-  else 
-    return 0;
+function sortById (a, b) {
+	if (a.public_id < b.public_id) {
+		return -1;
+	}
+	else if (a.public_id > b.public_id) {
+		return 1;
+	}
+	else {
+		return 0;
+	}
 }
 

--- a/fields/types/cloudinaryimage/CloudinaryImageField.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageField.js
@@ -335,7 +335,7 @@ module.exports = Field.create({
 			// build our url, accounting for selectPrefix
 			var uri = Keystone.adminPath + '/api/cloudinary/autocomplete?type=image';
 			if (selectPrefix) {
-				uri = uri + '?prefix=' + selectPrefix;
+				uri = uri + '&prefix=' + selectPrefix;
 			}
 
 			// make the request

--- a/fields/types/cloudinarymedia/CloudinaryMediaField.js
+++ b/fields/types/cloudinarymedia/CloudinaryMediaField.js
@@ -405,7 +405,7 @@ module.exports = Field.create({
 		return (
 			<div className="image-select">
 				<Select.Async
-					placeholder="Search for an image from Cloudinary ..."
+					placeholder="Search for an image or video from Cloudinary ..."
 					name={this.props.paths.select}
 					value={this.state.selectedCloudinaryMedia}
 					onChange={onChange}


### PR DESCRIPTION
These API endpoints are used to pre-populate the dropdown lists of available media when creating/editing a type (Activity, eg). The editor needs to see all available icons, but there is no loop to iterate through if there are more than the default amount. This PR creates that loop, and also increases the max returned in each call.