### PR TITLE
Add video codec to URLs of videos so they play correctly in the browser.

### DIFF
--- a/fields/types/cloudinarymedia/CloudinaryMediaField.js
+++ b/fields/types/cloudinarymedia/CloudinaryMediaField.js
@@ -46,7 +46,7 @@ module.exports = Field.create({
 	renderLightbox () {
 		const { value } = this.props;
 		if (!value || !Object.keys(value).length) return;
-
+		value.url = value.url.indexOf('vc_auto') === -1 ? value.url.replace('\/upload\/', '\/upload\/vc_auto\/') : value.url;
 		const images = [value.url];
 
 		return (


### PR DESCRIPTION
adding vc_auto to the video URLs ensures they play properly within the CMS (for preview purposes). This line adds vc_auto if its not already there.